### PR TITLE
switch to apereo instead of jasig in uportal 4.3

### DIFF
--- a/utils/uportal4/README.md
+++ b/utils/uportal4/README.md
@@ -8,10 +8,12 @@ You must first install ```utils/uportal4/layout.jsp``` in uPortal's webapp direc
 
 ### uPortal 4.3+
 
-You must modifiy ```layout_json_url``` in ```layout.jsp```:
+You must modifiy ```layout_json_url``` and ```org.jasig.portal.channels.CLogin.CasLoginUrl``` property in ```layout.jsp```:
 
 ```java
 String layout_json_url = "/api/v1/dlm/layout.json";
+
+String casLoginUrl = file_get_properties(request, conf_file).getProperty("org.apereo.portal.channels.CLogin.CasLoginUrl");
 ```
 
 ### uPortal 4.0 4.1 4.2

--- a/utils/uportal4/layout.jsp
+++ b/utils/uportal4/layout.jsp
@@ -26,7 +26,7 @@ String user = request.getRemoteUser();
 if ((user == null || user.equals("guest")) && request.getParameter("auth_checked") == null) {
     // redirect to CAS
     String conf_file = "/WEB-INF/classes/properties/security.properties";
-    String casLoginUrl = file_get_properties(request, conf_file).getProperty("org.jasig.portal.channels.CLogin.CasLoginUrl");
+    String casLoginUrl = file_get_properties(request, conf_file).getProperty("org.jasig.portal.channels.CLogin.CasLoginUrl"); // replace with "org.apereo.portal.channels.CLogin.CasLoginUrl" on uPortal 4.3+
 
     String currentUrl = request.getServletPath() + "?auth_checked&" + request.getQueryString();
     String loginParam = "?refUrl=" + urlencode(currentUrl);


### PR DESCRIPTION

With uPortal 4.3, classes are now in org.apereo.portal instead of org.jasig.portal.
layout.jsp needs a little change to adapt when running uPortal 4.3.
