### PR TITLE
uPortal 4.3 layout.jsp in a specific directory

### DIFF
--- a/utils/uportal4/README.md
+++ b/utils/uportal4/README.md
@@ -8,13 +8,7 @@ You must first install ```utils/uportal4/layout.jsp``` in uPortal's webapp direc
 
 ### uPortal 4.3+
 
-You must modifiy ```layout_json_url``` and ```org.jasig.portal.channels.CLogin.CasLoginUrl``` property in ```layout.jsp```:
-
-```java
-String layout_json_url = "/api/v1/dlm/layout.json";
-
-String casLoginUrl = file_get_properties(request, conf_file).getProperty("org.apereo.portal.channels.CLogin.CasLoginUrl");
-```
+Use file in ```utils/uportal43```
 
 ### uPortal 4.0 4.1 4.2
 

--- a/utils/uportal4/README.md
+++ b/utils/uportal4/README.md
@@ -8,10 +8,12 @@ You must first install ```utils/uportal4/layout.jsp``` in uPortal's webapp direc
 
 ### uPortal 4.3+
 
-You must modifiy ```layout_json_url``` in ```layout.jsp```:
+You must modifiy ```layout_json_url``` and ```org.jasig.portal.channels.CLogin.CasLoginUrl``` property in ```layout.jsp```:
 
 ```java
 String layout_json_url = "/api/v1/dlm/layout.json";
+
+String casLoginUrl = file_get_properties(request, conf_file).getProperty("org.apereo.portal.channels.CLogin.CasLoginUrl");
 ```
 
 ### uPortal 4.0 4.1 4.2

--- a/utils/uportal4/layout.jsp
+++ b/utils/uportal4/layout.jsp
@@ -26,7 +26,7 @@ String user = request.getRemoteUser();
 if ((user == null || user.equals("guest")) && request.getParameter("auth_checked") == null) {
     // redirect to CAS
     String conf_file = "/WEB-INF/classes/properties/security.properties";
-    String casLoginUrl = file_get_properties(request, conf_file).getProperty("org.jasig.portal.channels.CLogin.CasLoginUrl");
+    String casLoginUrl = file_get_properties(request, conf_file).getProperty("org.jasig.portal.channels.CLogin.CasLoginUrl"); // replace with "org.apereo.portal.channels.CLogin.CasLoginUrl" on uPortal 4.3+
 
     String currentUrl = request.getServletPath() + "?auth_checked&" + request.getQueryString();
     String loginParam = "?refUrl=" + urlencode(currentUrl);

--- a/utils/uportal43/README.md
+++ b/utils/uportal43/README.md
@@ -1,0 +1,17 @@
+You can use uPortal to compute user's layout (channels, apps).
+
+
+Installation
+------------
+
+You must first install ```utils/uportal43/layout.jsp``` in uPortal's webapp directory.
+
+
+Usage in ProlongationENT
+------------------------
+
+Configure ```layout_url``` in ProlongationENT ```config.json```:
+
+```js
+   "layout_url": "https://ent.univ.fr/layout.jsp",
+```

--- a/utils/uportal43/layout.jsp
+++ b/utils/uportal43/layout.jsp
@@ -1,0 +1,45 @@
+<%
+// wrapper around uportal /layout.json .
+// - put it in uportal webapp directory
+// - add this to ProlongationENT config.json:
+//     "layout_url": "https://uportal.univ.fr/layout.jsp",
+//
+%><%@ page import="java.io.InputStream"
+%><%@ page import="java.util.Properties" %><%!
+
+InputStream file_get_stream(HttpServletRequest request, String file) {
+    return request.getSession().getServletContext().getResourceAsStream(file);
+}
+Properties file_get_properties(HttpServletRequest request, String file) throws Exception {
+    Properties prop = new Properties();
+    prop.load(file_get_stream(request, file));
+    return prop;
+}
+String urlencode(String s) throws Exception {
+    return java.net.URLEncoder.encode(s, "utf-8");
+}
+
+%><% 
+String layout_json_url = "/api/v1/dlm/layout.json";
+String callback = request.getParameter("callback");
+String user = request.getRemoteUser();
+if ((user == null || user.equals("guest")) && request.getParameter("auth_checked") == null) {
+    // redirect to CAS
+    String conf_file = "/WEB-INF/classes/properties/security.properties";
+    String casLoginUrl = file_get_properties(request, conf_file).getProperty("org.apereo.portal.channels.CLogin.CasLoginUrl");
+
+    String currentUrl = request.getServletPath() + "?auth_checked&" + request.getQueryString();
+    String loginParam = "?refUrl=" + urlencode(currentUrl);
+    response.sendRedirect(casLoginUrl + urlencode(loginParam) + "&gateway=true");
+} else {
+    response.setContentType((callback != null ? "application/javascript": "application/json") + "; charset=UTF-8");
+    if (callback != null) {
+        out.print(callback + "(");
+        out.flush();
+    }
+    request.getRequestDispatcher(layout_json_url).include(request, response);
+    if (callback != null) out.println(")");
+}
+
+%>
+


### PR DESCRIPTION
With uPortal 4.3, classes are now in org.apereo.portal instead of org.jasig.portal.
Specific layout.jsp is in a separate directory